### PR TITLE
Fixes installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Most projects have rules of some kind about how to submit pull requests, which o
  - `npm install -g gulp jspm`
  - `npm install`
  - [`jspm`](http://jspm.io/) `install`
+ - `jspm bundle-sfx --minify pr.js build.min.js`
  - `gulp serve`
  - [`http://localhost:3003`](http://localhost:3003)
 


### PR DESCRIPTION
### Description
- This adds one critical missing line to the installation instructions.
### Test
1. Clone a clean PR.js repo
2. Follow [the installation instructions](https://github.com/radify/PR.js#get-going)
3. After running `gulp serve`, 
   - open [`http://localhost:3003`](http://localhost:3003)
   - **Assert that** the app loads properly in the browser
4. In the search box, enter "radify"
   - **Assert that** Radify's public repos display in the left hand column
5. Click on `angular-model`
   - **Assert that** one or more PRs load.
6. Click on `#22Revert should remove new properties`
   - **Assert that** you see Wolan
   - **Assert that** you see the complete PR message.
   - **Assert that** you see a mix of red and green test results
7. Click on `View`
   - **Assert that** it takes you to [the PR request on Github](https://github.com/radify/angular-model/pull/22)
