### PR TITLE
Fixed MASSIVE logo issue on Safari

### DIFF
--- a/css/pr.css
+++ b/css/pr.css
@@ -214,6 +214,9 @@ div.homeHeader h1 {
   margin: 42px auto 30px;
   max-width: 230px;
 }
+div.homeHeader h1 img {
+  max-width: 230px;
+}
 div.homeHeader p {
   color: #787f82;
   font-size: 32px;

--- a/less/pr.less
+++ b/less/pr.less
@@ -288,6 +288,10 @@ div.homeHeader {
 	h1 {
 		margin: 42px auto 30px;
 		max-width: 230px;
+
+		img {
+			max-width: 230px;
+		}
 	}
 
 	p {


### PR DESCRIPTION
Simple fix for Safari ignoring the parent max-width for the logo.
